### PR TITLE
Don't reset programming target until more programming data is received from network

### DIFF
--- a/serial/serbridge.c
+++ b/serial/serbridge.c
@@ -177,8 +177,11 @@ serbridgeRecvCb(void *arg, char *data, unsigned short len)
         (len == 2 && strncmp(data, "?\n", 2) == 0) ||
         (len == 3 && strncmp(data, "?\r\n", 3) == 0)) {
       startPGM = true;
-      conn->conn_mode = cmPGM;
 
+      // Don't actually reboot the target until we've actually received
+      // serial data to send to the target.
+      conn->conn_mode = cmPGMInit;
+      return;
     // If the connection starts with a telnet negotiation we will do telnet
     }
     else if (len >= 3 && strncmp(data, (char[]){IAC, WILL, ComPortOpt}, 3) == 0) {


### PR DESCRIPTION
I'm using esp-link over a very crowded Wifi network resulting in fairly high latency.  While trying to program my Arduino Uno, it appeared that the time between resetting the Arduino and actually starting programming was high enough that we 'missed' the bootloader and programming would fail.

This commit delays the actual resetting of the target until we've received actual programming data from the host.  At least on my system, with this patch I can successfully program the Arduino remotely.
