### PR TITLE
Fix syslog imports on non syslog build.

### DIFF
--- a/esp-link/cgiservices.c
+++ b/esp-link/cgiservices.c
@@ -2,7 +2,9 @@
 #include "cgiwifi.h"
 #include "cgi.h"
 #include "config.h"
-#include "syslog.h"
+#ifdef SYSLOG
+  #include "syslog.h"
+#endif
 #include "sntp.h"
 #include "cgimqtt.h"
 
@@ -109,21 +111,25 @@ int ICACHE_FLASH_ATTR cgiServicesInfo(HttpdConnData *connData) {
 
   os_sprintf(buff, 
     "{ "
+#ifdef SYSLOG
       "\"syslog_host\": \"%s\", "
       "\"syslog_minheap\": %d, "
       "\"syslog_filter\": %d, "
       "\"syslog_showtick\": \"%s\", "
       "\"syslog_showdate\": \"%s\", "
+#endif
       "\"timezone_offset\": %d, "
       "\"sntp_server\": \"%s\", "
       "\"mdns_enable\": \"%s\", "
       "\"mdns_servername\": \"%s\""
     " }",    
+#ifdef SYSLOG
     flashConfig.syslog_host,
     flashConfig.syslog_minheap,
     flashConfig.syslog_filter,
     flashConfig.syslog_showtick ? "enabled" : "disabled",
     flashConfig.syslog_showdate ? "enabled" : "disabled",
+#endif
     flashConfig.timezone_offset,
     flashConfig.sntp_server,
     flashConfig.mdns_enable ? "enabled" : "disabled",
@@ -138,6 +144,7 @@ int ICACHE_FLASH_ATTR cgiServicesInfo(HttpdConnData *connData) {
 int ICACHE_FLASH_ATTR cgiServicesSet(HttpdConnData *connData) {
   if (connData->conn == NULL) return HTTPD_CGI_DONE; // Connection aborted. Clean up.
 
+#ifdef SYSLOG
   int8_t syslog = 0;
 
   syslog |= getStringArg(connData, "syslog_host", flashConfig.syslog_host, sizeof(flashConfig.syslog_host));
@@ -154,6 +161,7 @@ int ICACHE_FLASH_ATTR cgiServicesSet(HttpdConnData *connData) {
   if (syslog > 0) {
     syslog_init(flashConfig.syslog_host);
   }
+#endif
 
   int8_t sntp = 0;
   sntp |= getInt8Arg(connData, "timezone_offset", &flashConfig.timezone_offset);

--- a/esp-link/main.c
+++ b/esp-link/main.c
@@ -29,13 +29,19 @@
 #include "config.h"
 #include "log.h"
 #include "gpio.h"
-#include "syslog.h"
 #include "cgiservices.h"
 
-#define NOTICE(format, ...) do {	                                          \
-	LOG_NOTICE(format, ## __VA_ARGS__ );                                      \
-	os_printf(format "\n", ## __VA_ARGS__);                                   \
-} while ( 0 )
+#ifdef SYSLOG
+  #include "syslog.h"
+  #define NOTICE(format, ...) do {	                                          \
+    LOG_NOTICE(format, ## __VA_ARGS__ );                                      \
+    os_printf(format "\n", ## __VA_ARGS__);                                   \
+  } while ( 0 )
+#else
+  #define NOTICE(format, ...) do {	                                          \
+    os_printf(format "\n", ## __VA_ARGS__);                                   \
+  } while ( 0 )
+#endif
 
 /*
 This is the main url->function dispatching data struct.

--- a/serial/serbridge.c
+++ b/serial/serbridge.c
@@ -10,7 +10,10 @@
 #include "console.h"
 #include "slip.h"
 #include "cmd.h"
-#include "syslog.h"
+
+#ifdef SYSLOG
+  #include "syslog.h"
+#endif
 
 #define SKIP_AT_RESET
 
@@ -405,12 +408,16 @@ serbridgeConnectCb(void *arg)
 #ifdef SERBR_DBG
   os_printf("Accept port %d, conn=%p, pool slot %d\n", conn->proto.tcp->local_port, conn, i);
 #endif
+#ifdef SYSLOG
   syslog(SYSLOG_FAC_USER, SYSLOG_PRIO_NOTICE, "esp-link", "Accept port %d, conn=%p, pool slot %d\n", conn->proto.tcp->local_port, conn, i);
+#endif
   if (i==MAX_CONN) {
 #ifdef SERBR_DBG
     os_printf("Aiee, conn pool overflow!\n");
 #endif
+#ifdef SYSLOG
 	syslog(SYSLOG_FAC_USER, SYSLOG_PRIO_WARNING, "esp-link", "Aiee, conn pool overflow!\n");
+#endif
     espconn_disconnect(conn);
     return;
   }


### PR DESCRIPTION
This commit removes all syslog imports, while building a esp-link version without syslog.
