### PR TITLE
Fix open sdk 1.5.2 systax checks (fixes #113).

### DIFF
--- a/esp-link/cgimqtt.c
+++ b/esp-link/cgimqtt.c
@@ -95,11 +95,11 @@ int ICACHE_FLASH_ATTR cgiMqttSet(HttpdConnData *connData) {
 
   if (mqtt_server < 0) return HTTPD_CGI_DONE;
   mqtt_server |= getBoolArg(connData, "mqtt-clean-session",
-      &flashConfig.mqtt_clean_session);
+      (bool *)&flashConfig.mqtt_clean_session);
 
   if (mqtt_server < 0) return HTTPD_CGI_DONE;
   int8_t mqtt_en_chg = getBoolArg(connData, "mqtt-enable",
-      &flashConfig.mqtt_enable);
+      (bool *)&flashConfig.mqtt_enable);
 
   char buff[16];
 
@@ -145,14 +145,14 @@ int ICACHE_FLASH_ATTR cgiMqttSet(HttpdConnData *connData) {
 
   // no action required if mqtt status settings change, they just get picked up at the
   // next status tick
-  if (getBoolArg(connData, "mqtt-status-enable", &flashConfig.mqtt_status_enable) < 0)
+  if (getBoolArg(connData, "mqtt-status-enable", (bool *)&flashConfig.mqtt_status_enable) < 0)
     return HTTPD_CGI_DONE;
   if (getStringArg(connData, "mqtt-status-topic",
         flashConfig.mqtt_status_topic, sizeof(flashConfig.mqtt_status_topic)) < 0)
     return HTTPD_CGI_DONE;
 
   // if SLIP-enable is toggled it gets picked-up immediately by the parser
-  int slip_update = getBoolArg(connData, "slip-enable", &flashConfig.slip_enable);
+  int slip_update = getBoolArg(connData, "slip-enable", (bool *)&flashConfig.slip_enable);
   if (slip_update < 0) return HTTPD_CGI_DONE;
   if (slip_update > 0) 
     DBG("SLIP-enable changed: %d\n", flashConfig.slip_enable);

--- a/esp-link/cgiservices.c
+++ b/esp-link/cgiservices.c
@@ -146,9 +146,9 @@ int ICACHE_FLASH_ATTR cgiServicesSet(HttpdConnData *connData) {
   if (syslog < 0) return HTTPD_CGI_DONE;
   syslog |= getUInt8Arg(connData, "syslog_filter", &flashConfig.syslog_filter);
   if (syslog < 0) return HTTPD_CGI_DONE;
-  syslog |= getBoolArg(connData, "syslog_showtick", &flashConfig.syslog_showtick);
+  syslog |= getBoolArg(connData, "syslog_showtick", (bool *)&flashConfig.syslog_showtick);
   if (syslog < 0) return HTTPD_CGI_DONE;
-  syslog |= getBoolArg(connData, "syslog_showdate", &flashConfig.syslog_showdate);
+  syslog |= getBoolArg(connData, "syslog_showdate", (bool *)&flashConfig.syslog_showdate);
   if (syslog < 0) return HTTPD_CGI_DONE;
 
   if (syslog > 0) {
@@ -166,7 +166,7 @@ int ICACHE_FLASH_ATTR cgiServicesSet(HttpdConnData *connData) {
   }
 
   int8_t mdns = 0;
-  mdns |= getBoolArg(connData, "mdns_enable", &flashConfig.mdns_enable);
+  mdns |= getBoolArg(connData, "mdns_enable", (bool *)&flashConfig.mdns_enable);
   if (mdns < 0) return HTTPD_CGI_DONE;
     
   if (mdns > 0) {


### PR DESCRIPTION
Add `(bool *)` casts to all `getBoolArgs` calls.
