### PR TITLE
Incorrect types

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ XTENSA_TOOLS_ROOT ?= $(abspath ../esp-open-sdk/xtensa-lx106-elf/bin)/
 
 # Base directory of the ESP8266 SDK package, absolute
 # Typically you'll download from Espressif's BBS, http://bbs.espressif.com/viewforum.php?f=5
-SDK_BASE	?= $(abspath ../esp_iot_sdk_v1.5.1)
+SDK_BASE	?= $(abspath ../esp-open-sdk/esp_iot_sdk_v1.5.2)
 
 # Esptool.py path and port, only used for 1-time serial flashing
 # Typically you'll use https://github.com/themadinventor/esptool
@@ -213,7 +213,7 @@ EXTRA_INCDIR 	= include .
 LIBS = c gcc hal phy pp net80211 wpa main lwip crypto
 
 # compiler flags using during compilation of source files
-CFLAGS	+= -Os -ggdb -std=c99 -Werror -Wpointer-arith -Wundef -Wall -Wl,-EL -fno-inline-functions \
+CFLAGS	+= -Os -ggdb -std=c99 -I$(SDK_BASE)/include -Wpointer-arith -Wundef -Wall -Wl,-EL -fno-inline-functions \
 		-nostdlib -mlongcalls -mtext-section-literals -ffunction-sections -fdata-sections \
 		-D__ets__ -DICACHE_FLASH -D_STDINT_H -Wno-address -DFIRMWARE_SIZE=$(ESP_FLASH_MAX) \
 		-DMCU_RESET_PIN=$(MCU_RESET_PIN) -DMCU_ISP_PIN=$(MCU_ISP_PIN) \

--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ XTENSA_TOOLS_ROOT ?= $(abspath ../esp-open-sdk/xtensa-lx106-elf/bin)/
 
 # Base directory of the ESP8266 SDK package, absolute
 # Typically you'll download from Espressif's BBS, http://bbs.espressif.com/viewforum.php?f=5
-SDK_BASE	?= $(abspath ../esp-open-sdk/esp_iot_sdk_v1.5.2)
+SDK_BASE	?= $(abspath ../esp_iot_sdk_v1.5.1)
 
 # Esptool.py path and port, only used for 1-time serial flashing
 # Typically you'll use https://github.com/themadinventor/esptool
@@ -213,7 +213,7 @@ EXTRA_INCDIR 	= include .
 LIBS = c gcc hal phy pp net80211 wpa main lwip crypto
 
 # compiler flags using during compilation of source files
-CFLAGS	+= -Os -ggdb -std=c99 -I$(SDK_BASE)/include -Wpointer-arith -Wundef -Wall -Wl,-EL -fno-inline-functions \
+CFLAGS	+= -Os -ggdb -std=c99 -Werror -Wpointer-arith -Wundef -Wall -Wl,-EL -fno-inline-functions \
 		-nostdlib -mlongcalls -mtext-section-literals -ffunction-sections -fdata-sections \
 		-D__ets__ -DICACHE_FLASH -D_STDINT_H -Wno-address -DFIRMWARE_SIZE=$(ESP_FLASH_MAX) \
 		-DMCU_RESET_PIN=$(MCU_RESET_PIN) -DMCU_ISP_PIN=$(MCU_ISP_PIN) \

--- a/esp-link/cgi.c
+++ b/esp-link/cgi.c
@@ -106,18 +106,18 @@ int8_t ICACHE_FLASH_ATTR getUInt16Arg(HttpdConnData *connData, char *name, uint1
   return 1;
 }
 
-int8_t ICACHE_FLASH_ATTR getBoolArg(HttpdConnData *connData, char *name, bool *config) {
+int8_t ICACHE_FLASH_ATTR getBoolArg(HttpdConnData *connData, char *name, uint8_t *config) {
   char buff[16];
   int len = httpdFindArg(connData->getArgs, name, buff, sizeof(buff));
   if (len < 0) return 0; // not found, skip
 
   if (os_strcmp(buff, "1") == 0 || os_strcmp(buff, "true") == 0) {
-    *config = true;
+    *config = 1;
     return 1;
   }
 
   if (os_strcmp(buff, "0") == 0 || os_strcmp(buff, "false") == 0) {
-    *config = false;
+    *config = 0;
     return 1;
   }
 

--- a/esp-link/cgi.h
+++ b/esp-link/cgi.h
@@ -26,7 +26,7 @@ int8_t getUInt16Arg(HttpdConnData *connData, char *name, uint16_t *config);
 
 // Get the HTTP query-string param 'name' and store it boolean value at 'config',
 // supports 1/true and 0/false, returns -1 on error, 0 if not found, 1 if found
-int8_t getBoolArg(HttpdConnData *connData, char *name, bool *config);
+int8_t getBoolArg(HttpdConnData *connData, char *name, uint8_t *config);
 
 int cgiMenu(HttpdConnData *connData);
 

--- a/esp-link/config.c
+++ b/esp-link/config.c
@@ -27,7 +27,7 @@ FlashConfig flashDefault = {
   .mqtt_host    = "\0", .mqtt_clientid = "\0",
   .mqtt_username= "\0", .mqtt_password = "\0", .mqtt_status_topic = "\0",
   .sys_descr 	  = "\0",
-  .rx_pullup	  = 1,  
+  .rx_pullup	  = 1,
   .sntp_server  = "us.pool.ntp.org\0",
   .syslog_host = "\0", .syslog_minheap = 8192, .syslog_filter = 7, .syslog_showtick = 1, .syslog_showdate = 0,
   .mdns_enable = 1, .mdns_servername = "http\0", .timezone_offset = 0


### PR DESCRIPTION
Reworked fixes for #113 

Fix a number of these warnings (made errors with -Werror):

esp-link/cgimqtt.c: In function 'cgiMqttSet':
esp-link/cgimqtt.c:98:7: error: passing argument 3 of 'getBoolArg' from incompatible pointer type [-Werror]
       &flashConfig.mqtt_clean_session);
       ^

getBoolArg is only ever used when passed a uint8_t pointer, so change the declaration to that.

It does not make sense to change the type of the variable passed in, as it defines a type in flash, which may introduce a flash layout incompatibility.

It is also not advisable to cast the uint8_t pointers to bool pointers, as the size of these datatypes are not guaranteed to be the same. 
