### PR TITLE
RFC 2217 working with Diabolo bootloader

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,5 +15,6 @@ esp-link.opensdf
 esp-link.sdf
 espfs/mkespfsimage/mman-win32/libmman.a
 .localhistory/
+Makefile.local
 tools/
 *.tgz

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,10 @@
 # Original from esphttpd and others...
 #VERBOSE=1
 
+#  Include optionnal local configuration
+#
+-include Makefile.local
+
 # --------------- toolchain configuration ---------------
 
 # Base directory for the compiler. Needs a / at the end.

--- a/serial/serbridge.h
+++ b/serial/serbridge.h
@@ -24,7 +24,8 @@ typedef struct serbridgeConnData {
   enum connModes	conn_mode;	// connection mode
   uint8_t		tn_state;	// Telnet state machine state
   char			tn_opt ;	// Telnet option
-  int			tn_vlen ;	// Telnet option value length
+  uint32_t		tn_value ;	// Telnet option value
+  char			tn_vlen ;	// Telnet option value length
   uint16		txbufferlen;	// length of data in txbuffer
   char			*txbuffer;	// buffer for the data to send
   char			*sentbuffer;	// buffer sent, awaiting callback to get freed

--- a/serial/serbridge.h
+++ b/serial/serbridge.h
@@ -12,22 +12,24 @@
 #define MAX_TXBUFFER (2*1460)
 
 enum connModes {
-  cmInit = 0,        // initialization mode: nothing received yet
-  cmPGMInit,         // initialization mode for programming
+  cmInit = 0,	     // initialization mode: nothing received yet
+  cmPGMInit,	     // initialization mode for programming
   cmTransparent,     // transparent mode
-  cmPGM,             // Arduino/AVR/ARM programming mode
-  cmTelnet,          // use telnet escape sequences for programming mode
+  cmPGM,	     // Arduino/AVR/ARM programming mode
+  cmTelnet,	     // use telnet escape sequences for programming mode
 };
 
 typedef struct serbridgeConnData {
-	struct espconn *conn;
-	enum connModes conn_mode;     // connection mode
-  uint8_t        telnet_state;
-	uint16         txbufferlen;   // length of data in txbuffer
-	char           *txbuffer;     // buffer for the data to send
-  char           *sentbuffer;   // buffer sent, awaiting callback to get freed
-  uint32_t       txoverflow_at; // when the transmitter started to overflow
-	bool           readytosend;   // true, if txbuffer can be sent by espconn_sent
+  struct espconn	*conn;
+  enum connModes	conn_mode;	// connection mode
+  uint8_t		tn_state;	// Telnet state machine state
+  char			tn_opt ;	// Telnet option
+  int			tn_vlen ;	// Telnet option value length
+  uint16		txbufferlen;	// length of data in txbuffer
+  char			*txbuffer;	// buffer for the data to send
+  char			*sentbuffer;	// buffer sent, awaiting callback to get freed
+  uint32_t		txoverflow_at;	// when the transmitter started to overflow
+  bool			readytosend;	// true, if txbuffer can be sent by espconn_sent
 } serbridgeConnData;
 
 // port1 is transparent&programming, second port is programming only


### PR DESCRIPTION
This is a partial implementation of the RFC 2217 that let's the host set (and retrieve) the serial controller's configuration: baudrate, data bits, stop bits, parity, control lines, BREAK.

I did it because I needed it to use my serial bootloader over a TCP connection.

It does what I need, but I there is no warranty that the RFC 2217 protocol is strictly respected.

Tested with the pyserial-3.0 implementation of RFC 2217.
