### PR TITLE
Fixes the Makefile's wifi station hardcoding functionality when starting in SOFTAP_MODE

### DIFF
--- a/esp-link/cgiwifi.c
+++ b/esp-link/cgiwifi.c
@@ -836,7 +836,7 @@ void ICACHE_FLASH_ATTR wifiInit() {
 
     // If STA is enabled switch to STA+AP to allow for recovery, it will then switch to STA-only
     // once it gets an IP address
-    if (x == 1) wifi_set_opmode(3);
+    wifi_set_opmode(3);
 
     // Call both STATION and SOFTAP default config
     wifi_station_get_config_default(&stconf);

--- a/esp-link/cgiwifi.c
+++ b/esp-link/cgiwifi.c
@@ -836,7 +836,7 @@ void ICACHE_FLASH_ATTR wifiInit() {
 
     // If STA is enabled switch to STA+AP to allow for recovery, it will then switch to STA-only
     // once it gets an IP address
-    wifi_set_opmode(3);
+    if (x == 1) wifi_set_opmode(3);
 
     // Call both STATION and SOFTAP default config
     wifi_station_get_config_default(&stconf);
@@ -850,6 +850,8 @@ void ICACHE_FLASH_ATTR wifiInit() {
     if (os_strlen((char*)stconf.ssid) == 0 && os_strlen((char*)stconf.password) == 0) {
         os_strncpy((char*)stconf.ssid, VERS_STR(STA_SSID), 32);
         os_strncpy((char*)stconf.password, VERS_STR(STA_PASS), 64);
+
+        wifi_set_opmode(3);
 
         DBG("Wifi pre-config trying to connect to AP %s pw %s\n",(char*)stconf.ssid, (char*)stconf.password);
 


### PR DESCRIPTION
The Makefile mentions

```
# The Wifi station configuration can be hard-coded here, which makes esp-link come up in STA+AP
# mode trying to connect to the specified AP *only* if the flash wireless settings are empty!
# This happens on a full serial flash and avoids having to hunt for the AP...
# STA_SSID ?=
# STA_PASS ?=
```

I defined both of these parameters but the application wouldn't connect to my home AP. I found out later that it was due to an if statement inside the wifiInit function. If a module is initially in SOFTAP_MODE (0x02) then it won't be set to STATIONAP_MODE, even if STA_SSID and STA_PASS are defined. I propose to remove the if condition so that the module always goes to STATIONAP_MODE at startup.
