### PR TITLE
V2: Adding the console uart format support 

### DIFF
--- a/esp-link/config.c
+++ b/esp-link/config.c
@@ -31,7 +31,10 @@ FlashConfig flashDefault = {
   .rx_pullup	  = 1,
   .sntp_server  = "us.pool.ntp.org\0",
   .syslog_host = "\0", .syslog_minheap = 8192, .syslog_filter = 7, .syslog_showtick = 1, .syslog_showdate = 0,
-  .mdns_enable = 1, .mdns_servername = "http\0", .timezone_offset = 0
+  .mdns_enable = 1, .mdns_servername = "http\0", .timezone_offset = 0,
+  .data_bits	= EIGHT_BITS,
+  .parity	= NONE_BITS,
+  .stop_bits	= ONE_STOP_BIT,
 };
 
 typedef union {
@@ -152,6 +155,12 @@ bool ICACHE_FLASH_ATTR configRestore(void) {
       os_memset(flashConfig.mqtt_old_host, 0, 32);
   } else os_printf("mqtt_host is '%s'\n", flashConfig.mqtt_host);
 
+  if (flashConfig.data_bits == 0) {
+      // restore to default 8N1
+      flashConfig.data_bits = flashDefault.data_bits;
+      flashConfig.parity = flashDefault.parity;
+      flashConfig.stop_bits = flashDefault.stop_bits;
+  }
   return true;
 }
 

--- a/esp-link/config.h
+++ b/esp-link/config.h
@@ -38,6 +38,9 @@ typedef struct {
   char     mdns_servername[32];
   int8_t   timezone_offset;
   char     mqtt_host[64];              // MQTT host we connect to, was 32-char mqtt_old_host
+  int8_t   data_bits;
+  int8_t   parity;
+  int8_t   stop_bits;
 } FlashConfig;
 extern FlashConfig flashConfig;
 

--- a/esp-link/main.c
+++ b/esp-link/main.c
@@ -74,6 +74,7 @@ HttpdBuiltInUrl builtInUrls[] = {
   { "/log/reset", cgiReset, NULL },
   { "/console/reset", ajaxConsoleReset, NULL },
   { "/console/baud", ajaxConsoleBaud, NULL },
+  { "/console/fmt", ajaxConsoleFormat, NULL },
   { "/console/text", ajaxConsole, NULL },
   { "/console/send", ajaxConsoleSend, NULL },
   //Enable the line below to protect the WiFi configuration with an username/password combo.
@@ -135,7 +136,8 @@ void user_init(void) {
   gpio_init();
   gpio_output_set(0, 0, 0, (1<<15)); // some people tie it to GND, gotta ensure it's disabled
   // init UART
-  uart_init(flashConfig.baud_rate, 115200);
+  uart_init(CALC_UARTMODE(flashConfig.data_bits, flashConfig.parity, flashConfig.stop_bits),
+            flashConfig.baud_rate, 115200);
   logInit(); // must come after init of uart
   // Say hello (leave some time to cause break in TX after boot loader's msg
   os_delay_us(10000L);

--- a/html/console.html
+++ b/html/console.html
@@ -18,7 +18,17 @@
           <option value="19200">19200</option>
           <option value="9600">9600</option>
         </select>
-        &nbsp; Fmt: 8N1
+        &nbsp; Fmt:
+        <select id="fmt-sel" class="pure-button" href="#">
+          <option value="8N1">8N1</option>
+          <option value="8E1">8E1</option>
+          <option value="8N2">8N2</option>
+          <option value="8E2">8E2</option>
+          <option value="7N1">7N1</option>
+          <option value="7E1">7E1</option>
+          <option value="7N2">7N2</option>
+          <option value="7E2">7E2</option>
+        </select>
       </p>
       <div class="pure-g">
         <div class="pure-u-1-4"><legend><b>Console</b></legend></div>
@@ -90,6 +100,20 @@
       ajaxSpin('POST', "/console/baud?rate="+baud,
         function(resp) { showNotification("" + baud + " baud set"); },
         function(s, st) { showWarning("Error setting baud rate: " + st); }
+      );
+    });
+
+    ajaxJson('GET', "/console/fmt",
+      function(data) { $("#fmt-sel").value = data.fmt; },
+      function(s, st) { showNotification(st); }
+    );
+
+    bnd($("#fmt-sel"), "change", function(ev) {
+      ev.preventDefault();
+      var fmt = $("#fmt-sel").value;
+      ajaxSpin('POST', "/console/fmt?fmt="+fmt,
+        function(resp) { showNotification("" + fmt + " format set"); },
+        function(s, st) { showWarning("Error setting format: " + st); }
       );
     });
 

--- a/serial/console.h
+++ b/serial/console.h
@@ -8,6 +8,7 @@ void ICACHE_FLASH_ATTR console_write_char(char c);
 int ajaxConsole(HttpdConnData *connData);
 int ajaxConsoleReset(HttpdConnData *connData);
 int ajaxConsoleBaud(HttpdConnData *connData);
+int ajaxConsoleFormat(HttpdConnData *connData);
 int ajaxConsoleSend(HttpdConnData *connData);
 int tplConsole(HttpdConnData *connData, char *token, void **arg);
 

--- a/serial/uart.h
+++ b/serial/uart.h
@@ -8,7 +8,7 @@ typedef void (*UartRecv_cb)(char *buf, short len);
 
 // Initialize UARTs to the provided baud rates (115200 recommended). This also makes the os_printf
 // calls use uart1 for output (for debugging purposes)
-void uart_init(UartBautRate uart0_br, UartBautRate uart1_br);
+void uart_init(uint32 conf0, UartBautRate uart0_br, UartBautRate uart1_br);
 
 // Transmit a buffer of characters on UART0
 void uart0_tx_buffer(char *buf, uint16 len);
@@ -27,5 +27,6 @@ void uart_add_recv_cb(UartRecv_cb cb);
 uint16_t uart0_rx_poll(char *buff, uint16_t nchars, uint32_t timeout_us);
 
 void uart0_baud(int rate);
+void uart_config(uint8 uart_no, UartBautRate baudrate, uint32 conf0);
 
 #endif /* __UART_H__ */


### PR DESCRIPTION
Some of the MCU use format other than 8N1.
Adding the support for other format.

Change compare to previous merge request V1:
- fix tab vs space in html.
- uart init now load the config from flash
- add code to migrate from old flash format.
  Which means it does not support 5 bits format. Who use 5 bits any way?
