### PR TITLE
use xtensa-lx106-elf-size to print section sizes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -283,6 +283,7 @@ AR		:= $(XTENSA_TOOLS_ROOT)xtensa-lx106-elf-ar
 LD		:= $(XTENSA_TOOLS_ROOT)xtensa-lx106-elf-gcc
 OBJCP		:= $(XTENSA_TOOLS_ROOT)xtensa-lx106-elf-objcopy
 OBJDP		:= $(XTENSA_TOOLS_ROOT)xtensa-lx106-elf-objdump
+ELF_SIZE	:= $(XTENSA_TOOLS_ROOT)xtensa-lx106-elf-size
 
 ####
 SRC_DIR		:= $(MODULES)
@@ -387,11 +388,11 @@ $(FW_BASE)/user1.bin: $(USER1_OUT) $(FW_BASE)
 	$(Q) $(OBJCP) --only-section .data -O binary $(USER1_OUT) eagle.app.v6.data.bin
 	$(Q) $(OBJCP) --only-section .rodata -O binary $(USER1_OUT) eagle.app.v6.rodata.bin
 	$(Q) $(OBJCP) --only-section .irom0.text -O binary $(USER1_OUT) eagle.app.v6.irom0text.bin
-	ls -ls eagle*bin
+	$(Q) $(ELF_SIZE) -A $(USER1_OUT) |grep -v " 0$$" |grep .
 	$(Q) COMPILE=gcc PATH=$(XTENSA_TOOLS_ROOT):$(PATH) python $(APPGEN_TOOL) $(USER1_OUT) 2 $(ESP_FLASH_MODE) $(ESP_FLASH_FREQ_DIV) $(ESP_SPI_SIZE) 0 >/dev/null
 	$(Q) rm -f eagle.app.v6.*.bin
 	$(Q) mv eagle.app.flash.bin $@
-	@echo "** user1.bin uses $$(stat -c '%s' $@) bytes of" $(ESP_FLASH_MAX) "available"
+	@echo "    user1.bin uses $$(stat -c '%s' $@) bytes of" $(ESP_FLASH_MAX) "available"
 	$(Q) if [ $$(stat -c '%s' $@) -gt $$(( $(ESP_FLASH_MAX) )) ]; then echo "$@ too big!"; false; fi
 
 $(FW_BASE)/user2.bin: $(USER2_OUT) $(FW_BASE)


### PR DESCRIPTION
This prints more sections than the ls was and seems like a more
appropriate way to print them, the grap removes debug sections (they
address of 0) and blank lines.  This also avoids printing **, which is
the characters make uses to indicate an failure.