### PR TITLE
Bugfix for issue #239 (setting baudrate via NVT)

### DIFF
--- a/serial/serbridge.c
+++ b/serial/serbridge.c
@@ -109,7 +109,7 @@ telnetUnwrap(serbridgeConnData *conn, uint8_t *inBuf, int len)
       case SetControl: state = TN_setControl; break;
       case SetDataSize: state = TN_setDataSize; break;
       case SetParity: state = TN_setParity; break;
-      case SetBaud: state = TN_setBaud; tn_baudCnt = 0; break;
+      case SetBaud: state = TN_setBaud; tn_baudCnt = 0; tn_baud = 0; break;
       default: state = TN_end; break;
       }
       break;


### PR DESCRIPTION
According to https://github.com/jeelabs/esp-link/issues/239 this commit
fixes a bug, when setting baudrate from Telnet control commands (NVT)
more than once.