### PR TITLE
Changes to esp-link for coping with REST replies longer than 100 bytes

### DIFF
--- a/cmd/cmd.h
+++ b/cmd/cmd.h
@@ -68,6 +68,8 @@ typedef enum {
   CMD_WIFI_GET_SSID,          // Query SSID currently connected to
   CMD_WIFI_START_SCAN,        // Trigger a scan (takes a long time)
 
+  CMD_RESP_CB_CONTINUE = 70,	// RESP_CB for a long packet
+
 } CmdName;
 
 typedef void (*cmdfunc_t)(CmdPacket *cmd);


### PR DESCRIPTION
This is the esp-link part of my proposed change.
Basically one additional command value that flags to el-client that there's more data to come.