### PR TITLE
Change reset line high output to no output

### DIFF
--- a/serial/serbridge.c
+++ b/serial/serbridge.c
@@ -143,7 +143,7 @@ telnetUnwrap(serbridgeConnData *conn, uint8_t *inBuf, int len)
         break;
       case DTR_OFF:
         if (mcu_reset_pin >= 0) {
-          GPIO_OUTPUT_SET(mcu_reset_pin, 1);
+          GPIO_DIS_OUTPUT(mcu_reset_pin);
           os_delay_us(100L);
         }
         break;
@@ -267,7 +267,7 @@ serbridgeReset()
 #endif
     GPIO_OUTPUT_SET(mcu_reset_pin, 0);
     os_delay_us(2000L); // esp8266 needs at least 1ms reset pulse, it seems...
-    GPIO_OUTPUT_SET(mcu_reset_pin, 1);
+    GPIO_DIS_OUTPUT(mcu_reset_pin);
   }
 #ifdef SERBR_DBG
   else { os_printf("MCU reset: no pin\n"); }
@@ -332,7 +332,7 @@ serbridgeRecvCb(void *arg, char *data, unsigned short len)
     os_delay_us(100L);
     if (mcu_isp_pin >= 0) GPIO_OUTPUT_SET(mcu_isp_pin, 0);
     os_delay_us(2000L);
-    if (mcu_reset_pin >= 0) GPIO_OUTPUT_SET(mcu_reset_pin, 1);
+    if (mcu_reset_pin >= 0) GPIO_DIS_OUTPUT(mcu_reset_pin);
     //os_delay_us(100L);
     //if (mcu_isp_pin >= 0) GPIO_OUTPUT_SET(mcu_isp_pin, 1);
     os_delay_us(1000L); // wait a millisecond before writing to the UART below
@@ -498,7 +498,7 @@ serbridgeDisconCb(void *arg)
     os_delay_us(100L);
     GPIO_OUTPUT_SET(mcu_reset_pin, 0);
     os_delay_us(100L);
-    GPIO_OUTPUT_SET(mcu_reset_pin, 1);
+    GPIO_DIS_OUTPUT(mcu_reset_pin);
   }
   conn->conn = NULL;
 }
@@ -580,7 +580,7 @@ serbridgeInitPins()
 
   // set both pins to 1 before turning them on so we don't cause a reset
   if (mcu_isp_pin >= 0)   GPIO_OUTPUT_SET(mcu_isp_pin, 1);
-  if (mcu_reset_pin >= 0) GPIO_OUTPUT_SET(mcu_reset_pin, 1);
+  if (mcu_reset_pin >= 0) GPIO_DIS_OUTPUT(mcu_reset_pin);
   // switch pin mux to make these pins GPIO pins
   if (mcu_reset_pin >= 0) makeGpio(mcu_reset_pin);
   if (mcu_isp_pin >= 0)   makeGpio(mcu_isp_pin);


### PR DESCRIPTION
This pull request changes the output status of the reset line when it is unasserted to input state (no output) so that it does not pull the line high and interfere with reset status when the SoC the ESP is connected to is under control of a PMIC.

Resolves #474