### PR TITLE
Enable faster baudrates

### DIFF
--- a/serial/console.c
+++ b/serial/console.c
@@ -76,7 +76,7 @@ ajaxConsoleBaud(HttpdConnData *connData) {
   len = httpdFindArg(connData->getArgs, "rate", buff, sizeof(buff));
   if (len > 0) {
     int rate = atoi(buff);
-    if (rate >= 300 && rate <= 1000000) {
+    if (rate >= 300 && rate <= 3000000) {
       uart0_baud(rate);
       flashConfig.baud_rate = rate;
       status = configSave() ? 200 : 400;


### PR DESCRIPTION
Why 1Mbit limit? Works well up to 3Mbit.